### PR TITLE
chore(cargo): update edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-group-imports"
 version = "0.1.5"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Group imports in Rust workspaces "
 repository = "https://github.com/cpg314/cargo-group-imports"


### PR DESCRIPTION
I was trying to use your cargo plugin, thanks for that btw 😄 .

I encounter a problem with your plugin when getting this

```
error[E0670]: `async fn` is not permitted in Rust 2015
```

but my code technically is in `2024`. So I'm wondering if that's not the plugin itself. I'm also on a recent version of rust. 1.88